### PR TITLE
Master pitstop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 
 # Created by https://www.gitignore.io/api/intellij,webstorm,pycharm,macos,windows,linux,django,node
 
+
+### Production ###
+/static/
+
+
 ### Django ###
 *.log
 *.pot


### PR DESCRIPTION
added a missing file (app/__init__.py) in order to get the uwsgi protocol working, and added the public static folder to gitignore. 