### PR TITLE
Polyfill

### DIFF
--- a/assets/js/APIFunctions.js
+++ b/assets/js/APIFunctions.js
@@ -1,3 +1,5 @@
+import 'whatwg-fetch';
+
 export function getActivityInfo(id, callback) {
     fetchFromServer('/api/activity/' + id).then(data => {
         callback(data[0].fields);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-select": "^1.0.0-rc.3",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "whatwg-fetch": "^2.0.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Works local, not sure if it will work on prod server, but I think it should.

https://www.npmjs.com/package/whatwg-fetch#usage 
Says that; 
1. You will also need a Promise polyfill for older browsers. We recommend taylorhakes/promise-polyfill for its small size and Promises/A+ compatibility.

2. For use with webpack, add this package in the entry configuration option before your application entry point:

3. entry: ['whatwg-fetch', ...]

But it works without all that, so then it should work on prod server as well  I guess? 